### PR TITLE
Fresh fruit vending control system

### DIFF
--- a/AT24C02/AT24C02.c
+++ b/AT24C02/AT24C02.c
@@ -410,9 +410,11 @@ uint8_t AT24C02_Clear(uint8_t beginaddr,uint8_t endaddr){
 	
 	if(status == HAL_OK){
 		printf("at24 clear ok\r\n");
+		return status;
 	}
 	else {
 		printf("at24 clear fail\r\n");
+		return status;
 	}
 }
 

--- a/AT24C02/AT24C02.c
+++ b/AT24C02/AT24C02.c
@@ -82,7 +82,16 @@ HAL_StatusTypeDef AT24C02_Read(uint16_t memAddress, uint8_t *data)
 }
 
 
-// 向 EEPROM 写入字节数组
+/**
+ * @brief 向EEPROM写入字节数组
+ * @param memAddress 起始地址
+ * @param data 数据指针
+ * @param length 数据长度
+ * @return 状态
+ * 
+ * return HAL_OK: 成功
+ * return HAL_ERROR: 失败
+ */
 HAL_StatusTypeDef AT24C02_Write_Array(uint16_t memAddress, uint8_t *data, uint16_t length)
 {
     HAL_StatusTypeDef status = HAL_OK;
@@ -95,6 +104,13 @@ HAL_StatusTypeDef AT24C02_Write_Array(uint16_t memAddress, uint8_t *data, uint16
         if (status != HAL_OK)
         {
             // 如果写入失败，立即返回错误
+            if(status == HAL_ERROR){
+                printf("AT24C02_Write_Array: Failed to write at address 0x%04X\n", memAddress + i);
+            }else if(status == HAL_BUSY){
+                printf("AT24C02_Write_Array: Busy at address 0x%04X\n", memAddress + i);
+            }else if(status == HAL_TIMEOUT){
+                printf("AT24C02_Write_Array: Timeout at address 0x%04X\n", memAddress + i);
+            }
             return status;
         }
 
@@ -129,7 +145,7 @@ HAL_StatusTypeDef AT24C02_Read_Array(uint16_t memAddress, uint8_t *data, uint16_
     return status;
 }
 
-HAL_StatusTypeDef fAT24C02_Read_256Bytes(uint16_t memAddress, uint8_t *data)
+HAL_StatusTypeDef AT24C02_Read_256Bytes(uint16_t memAddress, uint8_t *data)
 {
     HAL_StatusTypeDef status = HAL_OK;
 
@@ -138,8 +154,11 @@ HAL_StatusTypeDef fAT24C02_Read_256Bytes(uint16_t memAddress, uint8_t *data)
         status = AT24C02_Read(memAddress + i, &data[i]);
         if (status != HAL_OK)
         {
-            printf("AT24C02_Read_256Bytes: Failed to read at address 0x%04X\n", memAddress + i);
-            return status;
+            if(status == HAL_ERROR){
+                printf("AT24C02_Read_256Bytes: Failed to read at address 0x%04X\n", memAddress + i);
+            }else if(status == HAL_BUSY){
+                return status;
+            }
         }
     }
 
@@ -361,7 +380,7 @@ void Test_AT24C02_Base(void){
  if (HAL_I2C_Mem_Read(&hi2c2, AT24C02_READ, 0, I2C_MEMADD_SIZE_8BIT, ReadBuffer, BUFFER_SIZE, 100) != HAL_OK) {
      // 读取失败，设置错误指示
      printf("read error\r\n");
-     //HAL_GPIO_WritePin(GPIOC, GPIO_PIN_13, GPIO_PIN_SET);
+     // HAL_GPIO_WritePin(GPIOC, GPIO_PIN_13, GPIO_PIN_SET);
  } else {
      printf("read ok\r\n");
      for (uint16_t i = 0; i < BUFFER_SIZE; i++) {
@@ -384,8 +403,8 @@ void Test_AT24C02_Base(void){
 uint8_t AT24C02_Clear(uint8_t beginaddr,uint8_t endaddr){
 	
 	uint8_t memsize = endaddr - beginaddr;
-	uint8_t zero[] = {0x00};
-	uint8_t  status;
+	uint8_t zero[TEST_ARRAY_SIZE] = {0}; // 使用合适大小的缓冲区
+	uint8_t  status;        
 	
 	status = HAL_I2C_Mem_Write(&AT24C02_I2C_HANDLE,0xa0,beginaddr,I2C_MEMADD_SIZE_8BIT,zero,memsize,AT24C02_TIMEOUT);
 	

--- a/esp8266/esp8266.h
+++ b/esp8266/esp8266.h
@@ -7,6 +7,9 @@
 #include "usart.h"
 
 
+// ESP-AT指令集网址：https://espressif-docs.readthedocs-hosted.com/projects/esp-at/zh-cn/release-v2.2.0.0_esp8266/
+
+
 // 定义宏
 #define WIFI_SSID "1"
 #define WIFI_PASSWORD "88888888"
@@ -64,7 +67,14 @@ typedef struct
     void (*mqtt_message_callback)(const char *topic, const char *message);
 } ESP8266_HandleTypeDef;
 
-#include "main.h" // 根据你的 STM32 系列进行调整
+#include "main.h" 
+
+
+
+
+// 全局变量
+uint8_t g_wifi_status_need_parse_CWSTATE = 0;
+uint8_t g_wifi_status_need_parse_CWJAP = 0;
 
 // extern ESP8266_HandleTypeDef esp8266_handler;
 
@@ -72,21 +82,28 @@ typedef struct
 void            ESP8266_Init                		(ESP8266_HandleTypeDef *esp, UART_HandleTypeDef *huart);
 void            ESP8266_UART_IRQHandler     		(ESP8266_HandleTypeDef *esp);
 
-int             SP8266_SendCommand          		(ESP8266_HandleTypeDef *esp, const char *cmd, const char *expected_response, uint32_t timeout);
-int             SP8266_ConnectWiFi          		(ESP8266_HandleTypeDef *esp, const char *ssid, const char *password, uint32_t timeout);
-int             SP8266_SetMQTTConfig        		(ESP8266_HandleTypeDef *esp, const char *username, const char *password, const char *client_id, uint32_t timeout);
-int             SP8266_ConnectMQTT          		(ESP8266_HandleTypeDef *esp, const char *broker_ip, uint16_t port, uint32_t timeout);
-int             SP8266_SubscribeMQTT        		(ESP8266_HandleTypeDef *esp, const char *topic, MQTT_QoS qos, uint32_t timeout);
-int             SP8266_PublishMQTT          		(ESP8266_HandleTypeDef *esp, const char *topic, const char *message, MQTT_QoS qos, uint8_t retain, uint32_t timeout);
-int             SP8266_PublishMQTT_JSON     		(ESP8266_HandleTypeDef *esp, const char *topic, const char *key, const char *value, MQTT_QoS qos, uint8_t retain, uint32_t timeout);
+int             ESP8266_SendCommand          		(ESP8266_HandleTypeDef *esp, const char *cmd, const char *expected_response, uint32_t timeout);
+int             ESP8266_ConnectWiFi          		(ESP8266_HandleTypeDef *esp, const char *ssid, const char *password, uint32_t timeout);
+int             ESP8266_QueryWiFiStatus_CWSTATE     (ESP8266_HandleTypeDef *esp, uint32_t timeout);
+int             ESP8266_QueryWiFiStatus_CWJAP       (ESP8266_HandleTypeDef *esp, uint32_t timeout);
+int             ESP8266_SetMQTTConfig        		(ESP8266_HandleTypeDef *esp, const char *username, const char *password, const char *client_id, uint32_t timeout);
+int             ESP8266_ConnectMQTT          		(ESP8266_HandleTypeDef *esp, const char *broker_ip, uint16_t port, uint32_t timeout);
+int             ESP8266_SubscribeMQTT        		(ESP8266_HandleTypeDef *esp, const char *topic, MQTT_QoS qos, uint32_t timeout);
+int             ESP8266_PublishMQTT          		(ESP8266_HandleTypeDef *esp, const char *topic, const char *message, MQTT_QoS qos, uint8_t retain, uint32_t timeout);
+int             ESP8266_PublishMQTT_JSON     		(ESP8266_HandleTypeDef *esp, const char *topic, const char *key, const char *value, MQTT_QoS qos, uint8_t retain, uint32_t timeout);
 int             ESP8266_SendJSON            		(ESP8266_HandleTypeDef *esp, const char *topic, const char *json_data, uint32_t timeout);
 int             ESP8266_DisconnectMQTT      		(ESP8266_HandleTypeDef *esp, uint32_t timeout);
-int             SP8266_Close                		(ESP8266_HandleTypeDef *esp, uint32_t timeout);
+int             ESP8266_Close                		(ESP8266_HandleTypeDef *esp, uint32_t timeout);
 void            ESP8266_SetMQTTMessageCallback	    (ESP8266_HandleTypeDef *esp, void (*callback)(const char *topic, const char *message));
 void            ESP8266_ProcessReceivedData			(ESP8266_HandleTypeDef *esp);
 
 void            my_mqtt_callback            		(const char *topic, const char *message);
 void            MQTT_Connect                		(ESP8266_HandleTypeDef *data);
+
+
+uint8_t         ESP8266_CallBack                    (const char *message);
+void            ESP8266_QueryWiFiStatus_CWSTATE_Callback(const char *response);
+void            ESP8266_QueryWiFiStatus_CWJAP_Callback(const char *response);
 
 
 // JSON 工具函数

--- a/esp8266/esp8266.h
+++ b/esp8266/esp8266.h
@@ -73,8 +73,9 @@ typedef struct
 
 
 // 全局变量
-uint8_t g_wifi_status_need_parse_CWSTATE = 0;
-uint8_t g_wifi_status_need_parse_CWJAP = 0;
+extern uint8_t g_wifi_status_need_parse_CWSTATE;
+extern uint8_t g_wifi_status_need_parse_CWJAP;
+extern uint8_t g_mqtt_status_need_parse_MQTTCONN;
 
 // extern ESP8266_HandleTypeDef esp8266_handler;
 
@@ -86,9 +87,10 @@ int             ESP8266_SendCommand          		(ESP8266_HandleTypeDef *esp, cons
 int             ESP8266_ConnectWiFi          		(ESP8266_HandleTypeDef *esp, const char *ssid, const char *password, uint32_t timeout);
 int             ESP8266_QueryWiFiStatus_CWSTATE     (ESP8266_HandleTypeDef *esp, uint32_t timeout);
 int             ESP8266_QueryWiFiStatus_CWJAP       (ESP8266_HandleTypeDef *esp, uint32_t timeout);
-int             ESP8266_SetMQTTConfig        		(ESP8266_HandleTypeDef *esp, const char *username, const char *password, const char *client_id, uint32_t timeout);
-int             ESP8266_ConnectMQTT          		(ESP8266_HandleTypeDef *esp, const char *broker_ip, uint16_t port, uint32_t timeout);
-int             ESP8266_SubscribeMQTT        		(ESP8266_HandleTypeDef *esp, const char *topic, MQTT_QoS qos, uint32_t timeout);
+int             ESP8266_SetMQTTConfig        		(ESP8266_HandleTypeDef *esp, int link_id, int scheme, const char *client_id, const char *username, const char *password, int cert_key_ID, int CA_ID, const char *path, uint32_t timeout);
+int             ESP8266_ConnectMQTT          		(ESP8266_HandleTypeDef *esp, int link_id, const char *broker_ip, uint16_t port, int reconnect, uint32_t timeout);
+int             ESP8266_QueryMQTTStatus_Connect     (ESP8266_HandleTypeDef *esp, uint32_t timeout);
+int             ESP8266_SubscribeMQTT        		(ESP8266_HandleTypeDef *esp, int link_id, const char *topic, MQTT_QoS qos, uint32_t timeout);
 int             ESP8266_PublishMQTT          		(ESP8266_HandleTypeDef *esp, const char *topic, const char *message, MQTT_QoS qos, uint8_t retain, uint32_t timeout);
 int             ESP8266_PublishMQTT_JSON     		(ESP8266_HandleTypeDef *esp, const char *topic, const char *key, const char *value, MQTT_QoS qos, uint8_t retain, uint32_t timeout);
 int             ESP8266_SendJSON            		(ESP8266_HandleTypeDef *esp, const char *topic, const char *json_data, uint32_t timeout);
@@ -101,9 +103,10 @@ void            my_mqtt_callback            		(const char *topic, const char *me
 void            MQTT_Connect                		(ESP8266_HandleTypeDef *data);
 
 
-uint8_t         ESP8266_CallBack                    (const char *message);
-void            ESP8266_QueryWiFiStatus_CWSTATE_Callback(const char *response);
-void            ESP8266_QueryWiFiStatus_CWJAP_Callback(const char *response);
+uint8_t         ESP8266_CallBack                            (const char *message);
+uint8_t         ESP8266_QueryWiFiStatus_CWSTATE_Callback    (const char *response);
+uint8_t         ESP8266_QueryWiFiStatus_CWJAP_Callback      (const char *response);
+uint8_t         ESP8266_QueryMQTTStatus_Connect_Callback    (const char *response);
 
 
 // JSON 工具函数

--- a/esp8266/esp8266callback.c
+++ b/esp8266/esp8266callback.c
@@ -1,0 +1,172 @@
+#include "esp8266.h"
+
+
+
+
+/**
+ * @brief 回调函数
+ * 
+ * @param message 
+ * @return 
+ */
+uint8_t ESP8266_CallBack(const char *message){
+    if (g_wifi_status_need_parse_CWSTATE)
+    {
+        ESP8266_QueryWiFiStatus_CWSTATE_Callback(message);
+    }
+    else if (g_wifi_status_need_parse_CWJAP)
+    {
+        ESP8266_QueryWiFiStatus_CWJAP_Callback(message);
+    }
+    else 
+    {
+        return 0;
+    }
+}
+
+
+
+
+
+/**
+ * @brief 查询WiFi连接状态回调函数
+ * 
+ * 解析AT+CWSTATE?命令的响应，格式如下：
+ * +CWSTATE:<state>,<"ssid">
+ * OK
+ * 
+ * @param response AT命令的响应字符串
+ * 
+ * <state>：当前WiFi连接状态
+ *   0: 未连接
+ *   1: 已连接AP但未获取IP
+ *   2: 已连接AP并获取IP
+ *   3: 正在连接或重连
+ *   4: 已断开连接
+ * 
+ * <"ssid">：目标AP的SSID名称
+ */
+void ESP8266_QueryWiFiStatus_CWSTATE_Callback(const char *response)
+{
+    // 解析响应字符串
+    char *state_str = strstr(response, "+CWSTATE:");
+    if (state_str == NULL)
+    {
+        return;
+    }
+    else
+    {
+        // 解析状态和SSID
+        int state = 0;
+        char ssid[32] = {0};
+        
+        // 使用sscanf解析状态和SSID
+        if (sscanf(state_str, "+CWSTATE:%d,\"%[^\"]\"", &state, ssid) == 2)
+        {
+            // 根据状态进行相应处理
+            switch (state)
+            {
+            case 0:
+                printf("[ESP8266_QueryWiFiStatus_Callback]  WiFi Status:no connect\n");
+                g_wifi_status_need_parse_CWSTATE =  0;
+                FruitVendingData_SetNetworkConnected(&g_fruitVendingData,0);
+                break;
+            case 1:
+                printf("[ESP8266_QueryWiFiStatus_Callback]  WiFi Status:connect AP but no get IP, SSID: %s\n", ssid);
+                g_wifi_status_need_parse_CWSTATE =  0;
+                FruitVendingData_SetNetworkConnected(&g_fruitVendingData,0);
+                break;
+            case 2:
+                printf("[ESP8266_QueryWiFiStatus_Callback]  WiFi Status:connect AP and get IP, SSID: %s\n", ssid);
+                g_wifi_status_need_parse_CWSTATE =  0;
+                FruitVendingData_SetNetworkConnected(&g_fruitVendingData,1);
+                break;
+            case 3:
+                printf("[ESP8266_QueryWiFiStatus_Callback]  WiFi Status:connecting or reconnecting, SSID: %s\n", ssid);
+                g_wifi_status_need_parse_CWSTATE =  0;
+                FruitVendingData_SetNetworkConnected(&g_fruitVendingData,0);
+                break;
+            case 4:
+                printf("[ESP8266_QueryWiFiStatus_Callback]  WiFi Status:disconnect\n");
+                g_wifi_status_need_parse_CWSTATE =  0;
+                FruitVendingData_SetNetworkConnected(&g_fruitVendingData,0);
+                break;
+            default:
+                printf("[ESP8266_QueryWiFiStatus_Callback]  Unknown WiFi Status: %d\n", state);
+                g_wifi_status_need_parse_CWSTATE =  0;
+                FruitVendingData_SetNetworkConnected(&g_fruitVendingData,0);
+                break;
+            }
+        }
+        else
+        {
+            printf("[ESP8266_QueryWiFiStatus_Callback]  Parse WiFi Status failed\n");
+            g_wifi_status_need_parse_CWSTATE = 0;
+            FruitVendingData_SetNetworkConnected(&g_fruitVendingData,0);
+        }
+    }
+}
+
+/**
+ * @brief 查询与ESP Station连接的AP信息
+ * 
+ * 命令格式：AT+CWJAP?
+ * 响应格式：+CWJAP:<ssid>,<bssid>,<channel>,<rssi>,<pci_en>,<reconn_interval>,<listen_interval>,<scan_mode>,<pmf>
+ * 
+ * 参数说明：
+ * - ssid: 目标AP的SSID（需转义特殊字符,、"、\\）
+ * - bssid: 目标AP的MAC地址（当多个AP有相同SSID时必填）
+ * - channel: 信道号
+ * - rssi: 信号强度
+ * - pci_en: PCI认证模式
+ *   - 0: 支持所有加密方式（包括OPEN和WEP）
+ *   - 1: 仅支持WPA/WPA2加密
+ * - reconn_interval: Wi-Fi重连间隔（单位：秒，默认1，范围[0,7200]）
+ *   - 0: 不自动重连
+ *   - [1,7200]: 定时重连间隔
+ * - listen_interval: 监听AP beacon间隔（单位：AP beacon间隔，默认3，范围[1,100]）
+ * - scan_mode: 扫描模式
+ *   - 0: 快速扫描（连接第一个匹配AP）
+ *   - 1: 全信道扫描（连接信号最强AP）
+ * - pmf: 受保护的管理帧（PMF）配置
+ *   - bit 0: 支持PMF（优先PMF模式连接）
+ *   - bit 1: 需要PMF（拒绝不支持PMF的设备）
+ * 
+ * 错误码说明：
+ * 1: 连接超时
+ * 2: 密码错误
+ * 3: 无法找到目标AP
+ * 4: 连接失败
+ * 其他: 未知错误
+ */
+void ESP8266_QueryWiFiStatus_CWJAP_Callback(const char *response){
+    // 解析响应字符串
+    char *state_str = strstr(response, "+CWJAP:");
+    if (state_str == NULL)
+    {
+        return;
+    }
+
+    // 解析参数
+    char ssid[32] = {0};
+    char bssid[18] = {0};
+    int channel = 0;
+    int rssi = 0;
+    int pci_en = 0;
+    uint16_t reconn_interval = 0;
+    uint8_t listen_interval = 0;
+    uint8_t scan_mode = 0;
+    uint8_t pmf = 0;
+
+    // 使用sscanf解析参数
+    if (sscanf(state_str, "+CWJAP:%[^,],%[^,],%d,%d,%d,%d,%d,%d,%d", ssid, bssid, &channel, &rssi, &pci_en, &reconn_interval, &listen_interval, &scan_mode, &pmf) == 9)
+    {
+        printf("[ESP8266_QueryWiFiStatus_CWJAP_Callback]  WiFi Status:connect AP and get IP, SSID: %s\n", ssid);
+        g_wifi_status_need_parse_CWJAP = 0;
+    }
+    else
+    {
+        printf("[ESP8266_QueryWiFiStatus_CWJAP_Callback]  Parse WiFi Status failed\n");
+        g_wifi_status_need_parse_CWJAP = 0;
+    }  
+}

--- a/jdq/JDQ.c
+++ b/jdq/JDQ.c
@@ -2,9 +2,15 @@
 
 // 初始化继电器
 void Relay_Init(Relay *relay, GPIO_TypeDef *GPIO_Port, uint16_t GPIO_Pin) {
+    // 参数检查
+    if (relay == NULL || GPIO_Port == NULL) {
+        return;
+    }
+
     relay->GPIO_Port = GPIO_Port;
     relay->GPIO_Pin = GPIO_Pin;
     relay->State = RELAY_OFF;
+    relay->LastToggleTime = 0;
 
     // 配置 GPIO
     GPIO_InitTypeDef GPIO_InitStruct = {0};
@@ -20,15 +26,57 @@ void Relay_Init(Relay *relay, GPIO_TypeDef *GPIO_Port, uint16_t GPIO_Pin) {
 
 // 设置继电器状态
 void Relay_SetState(Relay *relay, RelayState state) {
+    if (relay == NULL) {
+        return;
+    }
     relay->State = state;
     HAL_GPIO_WritePin(relay->GPIO_Port, relay->GPIO_Pin, (state == RELAY_ON) ? GPIO_PIN_SET : GPIO_PIN_RESET);
 }
 
 // 切换继电器状态
 void Relay_Toggle(Relay *relay) {
-    if (relay->State == RELAY_ON) {
-        Relay_SetState(relay, RELAY_OFF);
-    } else {
-        Relay_SetState(relay, RELAY_ON);
+    if (relay == NULL) {
+        return;
     }
+    // 防抖处理
+    uint32_t currentTime = HAL_GetTick();
+    if (currentTime - relay->LastToggleTime < 50) { // 50ms防抖
+        return;
+    }
+    relay->LastToggleTime = currentTime;
+    
+    Relay_SetState(relay, (relay->State == RELAY_ON) ? RELAY_OFF : RELAY_ON);
+}
+
+// 安全控制继电器
+void HAL_Relay_Control(Relay *relay, RelayState state) {
+    if (relay == NULL || relay->State == state) {
+        return;
+    }
+    relay->State = state;
+    HAL_GPIO_WritePin(relay->GPIO_Port, relay->GPIO_Pin, (state == RELAY_ON) ? GPIO_PIN_SET : GPIO_PIN_RESET);
+}
+
+// 获取继电器当前状态
+RelayState Relay_GetState(Relay *relay) {
+    if (relay == NULL) {
+        return RELAY_OFF;
+    }
+    return relay->State;
+}
+
+// 检查继电器是否处于开启状态
+uint8_t Relay_IsOn(Relay *relay) {
+    if (relay == NULL) {
+        return 0;
+    }
+    return (relay->State == RELAY_ON);
+}
+
+// 检查继电器是否处于关闭状态
+uint8_t Relay_IsOff(Relay *relay) {
+    if (relay == NULL) {
+        return 1;
+    }
+    return (relay->State == RELAY_OFF);
 }

--- a/jdq/JDQ.h
+++ b/jdq/JDQ.h
@@ -1,22 +1,29 @@
 #ifndef JDQ_H
 #define JDQ_H
 
-
-
 #include "stm32f1xx_hal.h"
-
+#include "main.h"
 
 /**
- * 本文件是继电器的库的头文件
- * 结构体变量初始化之前应该先开启对应引脚的时钟
- * 默认高电平为触发电平
+ * @file JDQ.h
+ * @brief 继电器控制库头文件
+ * 
+ * 本库提供对继电器的初始化、控制和状态管理功能。
+ * 使用前需确保对应GPIO端口的时钟已开启。
+ * 默认高电平为触发电平。
+ * 
+ * 功能包括：
+ * - 继电器初始化
+ * - 设置继电器状态
+ * - 切换继电器状态
+ * - 安全控制继电器
+ * - 获取继电器状态
  */
- 
 
 // 继电器状态枚举
 typedef enum {
-    RELAY_OFF = 0,
-    RELAY_ON = 1
+    RELAY_OFF = 0,  // 继电器关闭
+    RELAY_ON = 1    // 继电器开启
 } RelayState;
 
 // 继电器对象结构体
@@ -24,13 +31,58 @@ typedef struct {
     GPIO_TypeDef *GPIO_Port;  // GPIO 端口
     uint16_t GPIO_Pin;        // GPIO 引脚
     RelayState State;         // 当前继电器状态
+    uint32_t LastToggleTime;  // 上次切换时间（用于防抖）
 } Relay;
-#include "main.h"
-
 
 // 函数声明
+
+/**
+ * @brief 初始化继电器
+ * @param relay 继电器对象指针
+ * @param GPIO_Port GPIO端口
+ * @param GPIO_Pin GPIO引脚
+ */
 void Relay_Init(Relay *relay, GPIO_TypeDef *GPIO_Port, uint16_t GPIO_Pin);
+
+/**
+ * @brief 设置继电器状态
+ * @param relay 继电器对象指针
+ * @param state 要设置的状态（RELAY_ON/RELAY_OFF）
+ */
 void Relay_SetState(Relay *relay, RelayState state);
+
+/**
+ * @brief 切换继电器状态
+ * @param relay 继电器对象指针
+ */
 void Relay_Toggle(Relay *relay);
+
+/**
+ * @brief 安全控制继电器（带状态检查）
+ * @param relay 继电器对象指针
+ * @param state 要设置的状态
+ */
+void HAL_Relay_Control(Relay *relay, RelayState state);
+
+/**
+ * @brief 获取继电器当前状态
+ * @param relay 继电器对象指针
+ * @return 当前继电器状态
+ */
+RelayState Relay_GetState(Relay *relay);
+
+/**
+ * @brief 检查继电器是否处于开启状态
+ * @param relay 继电器对象指针
+ * @return 1-开启，0-关闭
+ */
+uint8_t Relay_IsOn(Relay *relay);
+
+/**
+ * @brief 检查继电器是否处于关闭状态
+ * @param relay 继电器对象指针
+ * @return 1-关闭，0-开启
+ */
+uint8_t Relay_IsOff(Relay *relay);
 
 #endif // JDQ_H


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

此 pull request 引入了查询 WiFi 和 MQTT 连接状态的新功能，通过去抖动和状态管理增强了继电器控制库，改进了 EEPROM 驱动程序中的错误处理，并添加了通用的 JSON 打包模板函数。 它还修复了 UART 中断处理程序中潜在的缓冲区溢出。

新功能：
- 添加了使用 `AT+CWSTATE?` 和 `AT+CWJAP?` 命令查询 WiFi 连接状态的函数。
- 添加了使用 `AT+MQTTCONN?` 命令查询 MQTT 连接状态的函数。
- 实现了回调函数来解析来自 WiFi 和 MQTT 状态查询命令的响应。

Bug 修复：
- 通过在缓冲区已满时将 `rx_index` 重置为 0，修复了 UART 中断处理程序中潜在的缓冲区溢出。

增强功能：
- 通过添加具有去抖动的切换功能、具有状态检查的安全控制功能以及获取继电器状态的功能，改进了继电器控制库。
- 添加了用于创建 JSON 字符串的通用 JSON 打包模板函数。
- 向 AT24C02 EEPROM 驱动程序添加了更强大的错误处理和日志记录，包括针对不同故障模式的特定错误消息。

文档：
- 向继电器控制库头文件添加了文档，解释了该库的目的、功能和用法。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

This pull request introduces new features for querying WiFi and MQTT connection statuses, enhances the relay control library with debouncing and state management, improves error handling in the EEPROM driver, and adds a generic JSON packing template function. It also fixes a potential buffer overflow in the UART interrupt handler.

New Features:
- Adds functions to query the WiFi connection status using `AT+CWSTATE?` and `AT+CWJAP?` commands.
- Adds a function to query the MQTT connection status using the `AT+MQTTCONN?` command.
- Implements callback functions to parse the responses from the WiFi and MQTT status query commands.

Bug Fixes:
- Fixes a potential buffer overflow in the UART interrupt handler by resetting the `rx_index` to 0 when the buffer is full.

Enhancements:
- Improves the relay control library by adding a toggle function with debouncing, a safe control function with state checking, and functions to get the relay state.
- Adds a generic JSON packing template function for creating JSON strings.
- Adds more robust error handling and logging to the AT24C02 EEPROM driver, including specific error messages for different failure modes.

Documentation:
- Adds documentation to the relay control library header file, explaining the purpose, functions, and usage of the library.

</details>