### PR TITLE
修改主题宏定义

### DIFF
--- a/esp8266/esp8266.h
+++ b/esp8266/esp8266.h
@@ -20,7 +20,10 @@
 #define MQTT_CLIENT_ID "1"
 #define MQTT_IP "47.104.253.100"
 #define MQTT_PORT_NUM "18083"
-#define MQTT_TOPIC "/FFVending/control"            // 替换为你的 MQTT 主题  
+#define MQTT_TOPIC_Subscribe "/FFVending/control"            // 替换为你的 MQTT 主题  
+#define MQTT_TOPIC_Publish "/FFVending/data"
+#define MQTT_TOPIC_Will "/FFVending/Will"
+#define MQTT_TOPIC_Will_Message "FFVending:offline"
 #define TIMEOUT 1000
 
 typedef enum {
@@ -85,9 +88,11 @@ void            ESP8266_UART_IRQHandler     		(ESP8266_HandleTypeDef *esp);
 
 int             ESP8266_SendCommand          		(ESP8266_HandleTypeDef *esp, const char *cmd, const char *expected_response, uint32_t timeout);
 int             ESP8266_ConnectWiFi          		(ESP8266_HandleTypeDef *esp, const char *ssid, const char *password, uint32_t timeout);
+int             ESP8266_ReconnectWiFi          	    (ESP8266_HandleTypeDef *esp, uint32_t timeout);
 int             ESP8266_QueryWiFiStatus_CWSTATE     (ESP8266_HandleTypeDef *esp, uint32_t timeout);
 int             ESP8266_QueryWiFiStatus_CWJAP       (ESP8266_HandleTypeDef *esp, uint32_t timeout);
 int             ESP8266_SetMQTTConfig        		(ESP8266_HandleTypeDef *esp, int link_id, int scheme, const char *client_id, const char *username, const char *password, int cert_key_ID, int CA_ID, const char *path, uint32_t timeout);
+int             ESP8266_SetMQTTWill        		    (ESP8266_HandleTypeDef *esp, int link_id, const char *topic, const char *message, MQTT_QoS qos, uint8_t retain, uint32_t timeout);
 int             ESP8266_ConnectMQTT          		(ESP8266_HandleTypeDef *esp, int link_id, const char *broker_ip, uint16_t port, int reconnect, uint32_t timeout);
 int             ESP8266_QueryMQTTStatus_Connect     (ESP8266_HandleTypeDef *esp, uint32_t timeout);
 int             ESP8266_SubscribeMQTT        		(ESP8266_HandleTypeDef *esp, int link_id, const char *topic, MQTT_QoS qos, uint32_t timeout);


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

此 pull request 引入了 ESP8266 库的新功能和增强功能，包括重新连接到 WiFi、设置 MQTT 遗嘱消息以及更新 MQTT 主题。

新功能：
- 添加了重新连接到 WiFi 的函数。
- 添加了设置 MQTT 遗嘱消息的函数，该消息在设备意外断开连接时发送。

增强功能：
- 更新了 MQTT 连接函数，以设置 120 秒的默认 keepalive 值并禁用 clean session 标志。

杂项：
- 更新了 MQTT 主题，包括用于订阅、发布和遗嘱消息的单独主题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

This pull request introduces new features and enhancements to the ESP8266 library, including the ability to reconnect to WiFi, set a will message for MQTT, and updates MQTT topics.

New Features:
- Adds a function to reconnect to WiFi.
- Adds a function to set the MQTT will message, which is sent when the device disconnects unexpectedly.

Enhancements:
- Updates the MQTT connection function to set a default keepalive value of 120 seconds and disables the clean session flag.

Chores:
- Updates MQTT topics to include separate topics for subscribe, publish, and will messages.

</details>